### PR TITLE
Redirect the consul service logs to logfile

### DIFF
--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -5,7 +5,7 @@ After=network.target
 
 [Service]
 Environment=<%= @environment.map {|key, val| %Q{"#{key}=#{val}"} }.join(' ') %>
-ExecStart=<%= @command %>
+ExecStart=<%= @command %> >> /var/log/consul.log 2>&1
 ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
 User=<%= @user %>


### PR DESCRIPTION
Just like sysv, redirect the systemd service logs to `/var/log/consul.log`. Otherwise, all the service logs goto `/var/log/messages`