### PR TITLE
Fix tls_cipher_suites in configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- Fix the Ruby type for `tls_cipher_suites` config property (#501, #510)
 - Removed node send in helper.rb (Stop polutiting node object - Collides with hashicorp-vault too. So the practice should be stopped. Added extend to attributes/default
 - Changed testing to be circleci
 

--- a/libraries/consul_config_v0.rb
+++ b/libraries/consul_config_v0.rb
@@ -125,7 +125,7 @@ module ConsulCookbook
       attribute(:statsite_prefix, kind_of: String)
       attribute(:telemetry, kind_of: [Hash, Mash])
       attribute(:syslog_facility, kind_of: String)
-      attribute(:tls_cipher_suites, kind_of: Array)
+      attribute(:tls_cipher_suites, kind_of: String)
       attribute(:tls_min_version, equal_to: %w(tls10 tls11 tls12))
       attribute(:tls_prefer_server_cipher_suites, equal_to: [true, false])
       attribute(:translate_wan_addrs, equal_to: [true, false])

--- a/libraries/consul_config_v1.rb
+++ b/libraries/consul_config_v1.rb
@@ -119,7 +119,7 @@ module ConsulCookbook
       attribute(:statsite_prefix, kind_of: String)
       attribute(:telemetry, kind_of: [Hash, Mash])
       attribute(:syslog_facility, kind_of: String)
-      attribute(:tls_cipher_suites, kind_of: Array)
+      attribute(:tls_cipher_suites, kind_of: String)
       attribute(:tls_min_version, equal_to: %w(tls10 tls11 tls12))
       attribute(:tls_prefer_server_cipher_suites, equal_to: [true, false])
       attribute(:translate_wan_addrs, equal_to: [true, false])


### PR DESCRIPTION
`tls_cipher_suites` should be a comma separated string, not an array, per the [Consul docs](https://www.consul.io/docs/agent/options.html#tls_cipher_suites).

Closes #501 (in fact, this is a rebase & edit of @mfischer90’s original PR, so thanks to them for it!)