### PR TITLE
Restore the ability to set a custom open file limit

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -88,7 +88,7 @@ platforms:
       pid_one_command: /sbin/init
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
-        - RUN /usr/bin/apt-get install lsb-release net-tools -y
+        - RUN /usr/bin/apt-get install lsb-release net-tools procps -y
     attributes:
       poise-service:
         consul:
@@ -109,3 +109,12 @@ suites:
           acl_master_token: doublesecret
           acl_datacenter: FortMeade
           acl_default_policy: deny
+
+  - name: overrides
+    provisioner:
+      policyfile: test/fixtures/policies/default.rb
+    attributes:
+      consul:
+        config: *default-config
+        service:
+          nofile_limit: 2048

--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -50,6 +50,16 @@ suites:
       - windows-2012r2
       - windows-2016
 
+  - name: overrides
+    attributes:
+      consul:
+        config: *default-config
+        service:
+          nofile_limit: 2048
+    excludes:
+      - windows-2012r2
+      - windows-2016
+
   - name: client
     named_run_list: client
     excludes:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- Restore the ability to set a custom open file limit (#516)
 - Fix the Ruby type for `tls_cipher_suites` config property (#501, #510)
 - Removed node send in helper.rb (Stop polutiting node object - Collides with hashicorp-vault too. So the practice should be stopped. Added extend to attributes/default
 - Changed testing to be circleci

--- a/libraries/consul_service.rb
+++ b/libraries/consul_service.rb
@@ -42,6 +42,10 @@ module ConsulCookbook
       # @!attribute nssm_params
       # @return [String]
       attribute(:nssm_params, kind_of: Hash, default: lazy { node['consul']['service']['nssm_params'] })
+      # @!attribute nofile_limit
+      # Set the Consul process's open file limit.
+      # @return [Integer]
+      attribute(:nofile_limit, kind_of: Integer)
       # @!attribute program
       # The location of the Consul executable.
       # @return [String]
@@ -95,9 +99,9 @@ module ConsulCookbook
         service.user(new_resource.user)
         service.environment(new_resource.environment)
         service.restart_on_update(false)
-        service.options(:systemd, template: 'consul:systemd.service.erb')
-        service.options(:sysvinit, template: 'consul:sysvinit.service.erb')
-        service.options(:upstart, template: 'consul:upstart.service.erb', executable: new_resource.program)
+        service.options(:systemd, template: 'consul:systemd.service.erb', nofile_limit: new_resource.nofile_limit)
+        service.options(:sysvinit, template: 'consul:sysvinit.service.erb', nofile_limit: new_resource.nofile_limit)
+        service.options(:upstart, template: 'consul:upstart.service.erb', executable: new_resource.program, nofile_limit: new_resource.nofile_limit)
 
         if node.platform_family?('rhel') && node['platform_version'].to_i == 6
           service.provider(:sysvinit)

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -10,6 +10,9 @@ ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
+<%- if @options['nofile_limit'] -%>
+LimitNOFILE=<%= @options['nofile_limit'] %>
+<%- end -%>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -21,6 +21,9 @@ pidfile="<%= @pid_file %>"
 logfile="/var/log/$prog.log"
 lockfile="/var/lock/subsys/$prog"
 
+<%- if @options['nofile_limit'] -%>
+ulimit -n <%= @options['nofile_limit'] %>
+<%- end -%>
 <%- @environment.each do |key, val| -%>
 export <%= key %>="<%= val %>"
 <%- end -%>

--- a/templates/default/upstart.service.erb
+++ b/templates/default/upstart.service.erb
@@ -9,6 +9,9 @@ respawn
 respawn limit 10 5
 umask 022
 chdir <%= @directory %>
+<%- if @options['nofile_limit'] -%>
+limit nofile <%= @options['nofile_limit'] %> <%= @options['nofile_limit'] %>
+<%- end -%>
 <%- @environment.each do |key, val| -%>
 env <%= key %>="<%= val %>"
 <%- end -%>

--- a/test/integration/overrides/acl_spec.rb
+++ b/test/integration/overrides/acl_spec.rb
@@ -1,0 +1,28 @@
+describe command('curl -s "http://localhost:8500/v1/acl/info/anonymous"') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match('"ID":"anonymous"') }
+  its(:stdout) { should match('"Name":"Anonymous Token"') }
+  its(:stdout) { should match('"Type":"client"') }
+  its(:stdout) { should include '"Rules":""' }
+end
+
+describe file('/tmp/anonymous-notified') do
+  it { should_not exist }
+end
+
+describe command('curl -s "http://localhost:8500/v1/acl/info/management_token"') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match('[]') }
+end
+
+describe file('/tmp/management_token-notified') do
+  it { should exist }
+end
+
+describe command('curl -s "http://localhost:8500/v1/acl/info/reader_token"') do
+  its(:exit_status) { should eq 0 }
+  its(:stdout) { should match('"ID":"reader_token"') }
+  its(:stdout) { should match('"Name":""') }
+  its(:stdout) { should match('"Type":"client"') }
+  its(:stdout) { should include '"Rules":"key \"dummykey\"' }
+end

--- a/test/integration/overrides/default_spec.rb
+++ b/test/integration/overrides/default_spec.rb
@@ -100,7 +100,7 @@ when :systemd
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     its('mode') { should cmp '0644' }
-    its('content') { should_not include 'LimitNOFILE' }
+    its('content') { should include 'LimitNOFILE=2048' }
   end
 when :upstart
   describe file('/etc/init/consul.conf') do
@@ -108,7 +108,7 @@ when :upstart
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     its('mode') { should cmp '0644' }
-    its('content') { should_not include 'limit nofile' }
+    its('content') { should include 'limit nofile 2048 2048' }
   end
 when :sysv
   describe file('/etc/init.d/consul') do
@@ -116,6 +116,12 @@ when :sysv
     it { should be_owned_by 'root' }
     it { should be_grouped_into 'root' }
     its('mode') { should cmp '0755' }
-    its('content') { should_not include 'ulimit' }
+    its('content') { should include 'ulimit -n 2048' }
   end
+end
+
+pid = processes('consul agent').pids.first
+
+describe file("/proc/#{pid}/limits") do
+  its(:content) { should match(/^Max open files\W+2048\W+2048\W+files\W+$/) }
 end


### PR DESCRIPTION
This seems to have existed, at least for Upstart, in [older versions](https://github.com/sous-chefs/consul/blob/v0.11.1/attributes/default.rb#L123) of the cookbook, but disappeared with the conversion to poise-service.

The Kitchen suites have a pretty basic default config that I was hesitant to mess with, hence the new test suite, which could also be used to validate other config overrides in the future. If the additional build time is going to be a problem, I can rip those tests back out or put them in the default suite.

Signed-off-by: Jonathan Hartman <j@hartman.io>