### PR TITLE
Add `enable_local_script_checks' parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Change Log
 
+- Add `enable_local_script_checks` parameter (#540)
 - Fix the Ruby type for `tls_cipher_suites` config property (#501, #510)
 - Removed node send in helper.rb (Stop polutiting node object - Collides with hashicorp-vault too. So the practice should be stopped. Added extend to attributes/default
 - Changed testing to be circleci

--- a/libraries/consul_config_v0.rb
+++ b/libraries/consul_config_v0.rb
@@ -79,6 +79,7 @@ module ConsulCookbook
       attribute(:enable_acl_replication, equal_to: [true, false])
       attribute(:enable_debug, equal_to: [true, false])
       attribute(:enable_script_checks, equal_to: [true, false])
+      attribute(:enable_local_script_checks, equal_to: [true, false])
       attribute(:enable_syslog, equal_to: [true, false])
       attribute(:encrypt, kind_of: String)
       attribute(:encrypt_verify_incoming, equal_to: [true, false])
@@ -178,6 +179,7 @@ module ConsulCookbook
           enable_acl_replication
           enable_debug
           enable_script_checks
+          enable_local_script_checks
           enable_syslog
           encrypt
           encrypt_verify_incoming

--- a/libraries/consul_config_v1.rb
+++ b/libraries/consul_config_v1.rb
@@ -76,6 +76,7 @@ module ConsulCookbook
       attribute(:enable_acl_replication, equal_to: [true, false])
       attribute(:enable_debug, equal_to: [true, false])
       attribute(:enable_script_checks, equal_to: [true, false])
+      attribute(:enable_local_script_checks, equal_to: [true, false])
       attribute(:enable_syslog, equal_to: [true, false])
       attribute(:encrypt, kind_of: String)
       attribute(:encrypt_verify_incoming, equal_to: [true, false])
@@ -165,6 +166,7 @@ module ConsulCookbook
           enable_acl_replication
           enable_debug
           enable_script_checks
+          enable_local_script_checks
           enable_syslog
           encrypt
           encrypt_verify_incoming


### PR DESCRIPTION
# Description
The `enable_local_script_checks` parameter enables script checks defined in local config files. This disables checks defined via the HTTP API.

## Issues Resolved
* Fixes: #517.

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
