### PR TITLE
Cookstyle fixes

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,1 +1,1 @@
---default-path test/spec --color
+--default-path spec --color

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,8 +1,0 @@
----
-Style/GuardClause:
-  Enabled: false
-Style/ModuleFunction:
-  Enabled: false
-AllCops:
-  Exclude:
-    - 'Dangerfile'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Consul Cookbook
 
 [![Cookbook Version](https://img.shields.io/cookbook/v/consul.svg)](https://supermarket.chef.io/cookbooks/consul)
-[![Build Status](https://circleci.com/gh/sous-chefs/consul.svg?style=svg)](https://circleci.com/gh/sous-chefs/consul)
+[![CI State](https://github.com/sous-chefs/consul/workflows/ci/badge.svg)](https://github.com/sous-chefs/consul/actions?query=workflow%3Aci)
 [![OpenCollective](https://opencollective.com/sous-chefs/backers/badge.svg)](#backers)
 [![OpenCollective](https://opencollective.com/sous-chefs/sponsors/badge.svg)](#sponsors)
 [![License](https://img.shields.io/badge/License-Apache%202.0-green.svg)](https://opensource.org/licenses/Apache-2.0)

--- a/chefignore
+++ b/chefignore
@@ -1,5 +1,5 @@
 # Put files/directories that should be ignored in this file when uploading
-# or sharing to the community site.
+# to a chef-server or supermarket.
 # Lines that start with '# ' are comments.
 
 # OS generated files #
@@ -51,8 +51,22 @@ spec/*
 spec/fixtures/*
 test/*
 features/*
+examples/*
 Guardfile
 Procfile
+.kitchen*
+kitchen*
+*.yml
+.circleci/*.yml
+.delivery/project.toml
+.github/*
+documentation/*
+spec/*
+Rakefile
+.foodcritic
+.mdlrc
+Dangerfile
+
 
 # SCM #
 #######
@@ -69,13 +83,17 @@ Procfile
 
 # Berkshelf #
 #############
+Berksfile
+Berksfile.lock
 cookbooks/*
 tmp
 
 # Cookbooks #
 #############
-CONTRIBUTING
+CONTRIBUTING*
 CHANGELOG*
+TESTING*
+MAINTAINERS.toml
 
 # Strainer #
 ############
@@ -88,7 +106,3 @@ Strainerfile
 ###########
 .vagrant
 Vagrantfile
-
-# Travis #
-##########
-.travis.yml

--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -48,7 +48,7 @@ module ConsulCookbook
           end
 
           url = format(options[:archive_url], version: options[:version], basename: options[:archive_basename])
-          poise_archive url do
+          poise_archive url do # cookstyle: disable ChefDeprecations/PoiseArchiveUsage
             destination join_path(options[:extract_to], new_resource.version)
             source_properties checksum: options[:archive_checksum]
             strip_components 0

--- a/libraries/consul_policy.rb
+++ b/libraries/consul_policy.rb
@@ -2,7 +2,7 @@
 # Cookbook: consul
 # License: Apache 2.0
 #
-# Copyright 2014-2016, Bloomberg Finance L.P.
+# Copyright:: 2014-2016, Bloomberg Finance L.P.
 #
 require 'poise'
 
@@ -63,11 +63,11 @@ module ConsulCookbook
         unless up_to_date?
           policy = Diplomat::Policy.list.select { |p| p['Name'].downcase == new_resource.policy_name.downcase }
           if policy.empty?
-            converge_by %|creating ACL policy "#{new_resource.policy_name.downcase}"| do
+            converge_by %(creating ACL policy "#{new_resource.policy_name.downcase}") do
               Diplomat::Policy.create(new_resource.to_acl)
             end
           else
-            converge_by %|updating ACL policy "#{new_resource.policy_name.downcase}"| do
+            converge_by %(updating ACL policy "#{new_resource.policy_name.downcase}") do
               Diplomat::Policy.update(new_resource.to_acl.merge('ID' => policy.first['ID']))
             end
           end
@@ -76,7 +76,7 @@ module ConsulCookbook
 
       def action_delete
         configure_diplomat
-        converge_by %|deleting ACL policy "#{new_resource.policy_name.downcase}"| do
+        converge_by %(deleting ACL policy "#{new_resource.policy_name.downcase}") do
           policy = Diplomat::Policy.list.select { |p| p['Name'].downcase == new_resource.policy_name.downcase }
           Diplomat::Policy.delete(policy['ID']) unless policy.empty?
         end
@@ -104,7 +104,7 @@ module ConsulCookbook
           return false if old_policy_id.empty?
           old_policy = Diplomat::Policy.read(old_policy_id.first['ID'], {}, :return)
           return false if old_policy.nil?
-          old_policy.first.select! { |k, _v| %w[Name Description Rules].include?(k) }
+          old_policy.first.select! { |k, _v| %w(Name Description Rules).include?(k) }
           old_policy['Description'].downcase!
           old_policy.first == new_resource.to_acl
         end
@@ -113,7 +113,7 @@ module ConsulCookbook
       def retry_block(opts = {}, &_block)
         opts = {
           max_tries: 3, # Number of tries
-          sleep:     0, # Seconds to sleep between tries
+          sleep: 0, # Seconds to sleep between tries
         }.merge(opts)
 
         try_count = 1

--- a/libraries/consul_role.rb
+++ b/libraries/consul_role.rb
@@ -2,7 +2,7 @@
 # Cookbook: consul
 # License: Apache 2.0
 #
-# Copyright 2014-2016, Bloomberg Finance L.P.
+# Copyright:: 2014-2016, Bloomberg Finance L.P.
 #
 require 'poise'
 
@@ -63,11 +63,11 @@ module ConsulCookbook
         unless up_to_date?
           role = Diplomat::Role.list.select { |p| p['Name'] == new_resource.role_name }
           if role.empty?
-            converge_by %|creating ACL role "#{new_resource.role_name}"| do
+            converge_by %(creating ACL role "#{new_resource.role_name}") do
               Diplomat::Role.create(new_resource.to_acl)
             end
           else
-            converge_by %|updating ACL role "#{new_resource.role_name}"| do
+            converge_by %(updating ACL role "#{new_resource.role_name}") do
               Diplomat::Role.update(new_resource.to_acl.merge('ID' => role.first['ID']))
             end
           end
@@ -76,7 +76,7 @@ module ConsulCookbook
 
       def action_delete
         configure_diplomat
-        converge_by %|deleting ACL role "#{new_resource.role_name}"| do
+        converge_by %(deleting ACL role "#{new_resource.role_name}") do
           role = Diplomat::Role.list.select { |p| p['Name'] == new_resource.role_name }
           Diplomat::Role.delete(role['ID']) unless role.empty?
         end
@@ -102,7 +102,7 @@ module ConsulCookbook
         retry_block(max_tries: 3, sleep: 0.5) do
           old_role = Diplomat::Role.list.select { |p| p['Name'] == new_resource.role_name }.first
           return false if old_role.nil?
-          old_role.select! { |k, _v| %w[Name Description Policies ServiceIdentities].include?(k) }
+          old_role.select! { |k, _v| %w(Name Description Policies ServiceIdentities).include?(k) }
           old_role == new_resource.to_acl
         end
       end
@@ -110,7 +110,7 @@ module ConsulCookbook
       def retry_block(opts = {}, &_block)
         opts = {
           max_tries: 3, # Number of tries
-          sleep:     0, # Seconds to sleep between tries
+          sleep: 0, # Seconds to sleep between tries
         }.merge(opts)
 
         try_count = 1

--- a/libraries/consul_token.rb
+++ b/libraries/consul_token.rb
@@ -2,7 +2,7 @@
 # Cookbook: consul
 # License: Apache 2.0
 #
-# Copyright 2014-2016, Bloomberg Finance L.P.
+# Copyright:: 2014-2016, Bloomberg Finance L.P.
 #
 require 'poise'
 
@@ -80,11 +80,11 @@ module ConsulCookbook
         unless up_to_date?
           old_token = Diplomat::Token.list.select { |p| p['Description'].downcase == new_resource.description.downcase }
           if old_token.empty?
-            converge_by %|creating ACL token "#{new_resource.description.downcase}"| do
+            converge_by %(creating ACL token "#{new_resource.description.downcase}") do
               Diplomat::Token.create(new_resource.to_acl)
             end
           else
-            converge_by %|updating ACL token "#{new_resource.description.downcase}"| do
+            converge_by %(updating ACL token "#{new_resource.description.downcase}") do
               Diplomat::Token.update(new_resource.to_acl.merge('AccessorID' => old_token.first['AccessorID']))
             end
           end
@@ -93,7 +93,7 @@ module ConsulCookbook
 
       def action_delete
         configure_diplomat
-        converge_by %|deleting ACL token "#{new_resource.description.downcase}"| do
+        converge_by %(deleting ACL token "#{new_resource.description.downcase}") do
           token = Diplomat::Token.list.select { |p| p['Description'].downcase == new_resource.description.downcase }
           Diplomat::Token.delete(token['AccessorID']) unless token.empty?
         end
@@ -119,7 +119,7 @@ module ConsulCookbook
         retry_block(max_tries: 3, sleep: 0.5) do
           old_token_id = Diplomat::Token.list.select { |p| p['Description'].downcase == new_resource.description.downcase }
           if old_token_id.empty?
-            Chef::Log.warn %|Token with description "#{new_resource.description.downcase}" was not found. Will create.|
+            Chef::Log.warn %(Token with description "#{new_resource.description.downcase}" was not found. Will create.)
             return false
           end
           old_token = Diplomat::Token.read(old_token_id.first['AccessorID'], {}, :return)
@@ -132,7 +132,7 @@ module ConsulCookbook
       def retry_block(opts = {}, &_block)
         opts = {
           max_tries: 3, # Number of tries
-          sleep:     0, # Seconds to sleep between tries
+          sleep: 0, # Seconds to sleep between tries
         }.merge(opts)
 
         try_count = 1

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -9,7 +9,7 @@ module ConsulCookbook
   module Helpers
     include Chef::Mixin::ShellOut
 
-    extend self
+    module_function
 
     def arch_64?
       node['kernel']['machine'] =~ /x86_64/ ? true : false

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,6 @@
 name 'consul'
-maintainer 'John Bellone'
-maintainer_email 'jbellone@bloomberg.net'
+maintainer 'Sous Chefs'
+maintainer_email 'help@sous-chefs.org'
 license 'Apache-2.0'
 description 'Application cookbook which installs and configures Consul.'
 version '3.2.0'
@@ -12,8 +12,7 @@ supports 'solaris2'
 supports 'arch'
 supports 'windows'
 
-# build-essential is obsolete in chef 14+
-# ~FC121
+depends 'build-essential', '>= 5.0.0' # required for the resource
 depends 'nssm', '>= 4.0.0'
 depends 'golang'
 depends 'poise', '~> 2.2'
@@ -21,7 +20,7 @@ depends 'poise-archive', '~> 1.3'
 depends 'poise-service', '~> 1.4'
 depends 'windows', '~> 3.1'
 
-source_url 'https://github.com/johnbellone/consul-cookbook'
-issues_url 'https://github.com/johnbellone/consul-cookbook/issues'
+source_url 'https://github.com/sous-chefs/consul'
+issues_url 'https://github.com/sous-chefs/consul/issues'
 
 chef_version '>= 12.1'

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,7 +12,7 @@ supports 'solaris2'
 supports 'arch'
 supports 'windows'
 
-depends 'build-essential', '>= 5.0.0' # required for the resource
+depends 'build-essential', '>= 5.0.0' # cookstyle: disable ChefModernize/UnnecessaryDependsChef14
 depends 'nssm', '>= 4.0.0'
 depends 'golang'
 depends 'poise', '~> 2.2'

--- a/recipes/client_gem.rb
+++ b/recipes/client_gem.rb
@@ -5,14 +5,7 @@
 # Copyright:: 2014-2016, Bloomberg Finance L.P.
 #
 
-if Chef::Resource::ChefGem.instance_methods(false).include?(:compile_time)
-  chef_gem node[cookbook_name]['diplomat_gem'] do
-    version node['consul']['diplomat_version'] if node['consul']['diplomat_version']
-    compile_time true
-  end
-else
-  chef_gem node[cookbook_name]['diplomat_gem'] do
-    version node['consul']['diplomat_version'] if node['consul']['diplomat_version']
-    action :nothing
-  end.run_action(:install)
+chef_gem node[cookbook_name]['diplomat_gem'] do
+  version node['consul']['diplomat_version'] if node['consul']['diplomat_version']
+  compile_time true
 end


### PR DESCRIPTION
Minor updates for style
Remove the .rubocop.yml file
Assume a version of Chef released in the last 4 years which can handle
compile time gem installs

Signed-off-by: Tim Smith <tsmith@chef.io>