### PR TITLE
fix undefined method 'join_path' for PoiseArchive::Resources::PoiseAr…

### DIFF
--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -9,7 +9,7 @@ module ConsulCookbook
   module Helpers
     include Chef::Mixin::ShellOut
 
-    module_function
+    extend self
 
     def arch_64?
       node['kernel']['machine'] =~ /x86_64/ ? true : false


### PR DESCRIPTION
Fix for #545 (`extend self` keeps the instance methods public, but `module_function` makes them private.)

cc @tas50