### PR TITLE
Update deps and chef

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,8 +41,9 @@ jobs:
       matrix:
         os:
           - 'centos-7'
-          - 'debian-8'
+          - 'centos-8'
           - 'debian-9'
+          - 'debian-10'
           - 'ubuntu-1604'
           - 'ubuntu-1804'
           - 'amazonlinux-2'

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -3,7 +3,7 @@ driver:
   name: dokken
   privileged: true
   env: [CHEF_LICENSE=accept]
-  chef_version: '13.12.14'
+  chef_version: 14
 
 transport:
   name: dokken
@@ -21,9 +21,9 @@ platforms:
         consul:
           provider: systemd
 
-  - name: centos-6
+  - name: centos-8
     driver:
-      image: dokken/centos-6
+      image: dokken/centos-8
       pid_one_command: /sbin/init
       intermediate_instructions:
         - RUN yum -y install which initscripts net-tools
@@ -54,9 +54,9 @@ platforms:
         consul:
           provider: systemd
 
-  - name: debian-8
+  - name: debian-9
     driver:
-      image: dokken/debian-8
+      image: dokken/debian-9
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update
@@ -65,9 +65,9 @@ platforms:
         consul:
           provider: systemd
 
-  - name: debian-9
+  - name: debian-10
     driver:
-      image: dokken/debian-9
+      image: dokken/debian-10
       pid_one_command: /bin/systemd
       intermediate_instructions:
         - RUN /usr/bin/apt-get update

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -21,9 +21,9 @@ platforms:
   - name: ubuntu-16.04
   - name: ubuntu-18.04
   - name: centos-7
-  - name: centos-6
+  - name: centos-8
   - name: debian-9
-  - name: debian-8
+  - name: debian-10
   - name: windows-2012r2
     driver:
       box: mwrock/Windows2012R2

--- a/metadata.rb
+++ b/metadata.rb
@@ -18,9 +18,8 @@ depends 'golang'
 depends 'poise', '~> 2.2'
 depends 'poise-archive', '~> 1.3'
 depends 'poise-service', '~> 1.4'
-depends 'windows', '~> 3.1'
 
 source_url 'https://github.com/sous-chefs/consul'
 issues_url 'https://github.com/sous-chefs/consul/issues'
 
-chef_version '>= 12.1'
+chef_version '>= 13.4'


### PR DESCRIPTION
# Description

Update Chef minimum version.
* Eliminates the need for the windows cookbook.
* Update Linux testing versions.
* Set minimum Chef version to 13.4.
* Update dokken testing to Chef 14.

## Issues Resolved

Fixes: https://github.com/sous-chefs/consul/issues/503

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
