### PR TITLE
Only set `name` if the parameters are not an array

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 - Only set `name` if the parameters are not an array #568
 
-## [4.0.3](https://github.com/sous-chefs/consul/tree/v4.0.3 (2020-07-20)
+## [4.0.3](https://github.com/sous-chefs/consul/tree/v4.0.3) (2020-07-20)
 
 - resolved cookstyle error: libraries/consul_installation_binary.rb:43:7 refactor: `ChefModernize/ActionMethodInResource`
 - resolved cookstyle error: libraries/consul_installation_binary.rb:74:7 refactor: `ChefModernize/ActionMethodInResource`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+- Only set `name` if the parameters are not an array #568
+
 ## [4.0.3](https://github.com/sous-chefs/consul/tree/v4.0.3 (2020-07-20)
 
 - resolved cookstyle error: libraries/consul_installation_binary.rb:43:7 refactor: `ChefModernize/ActionMethodInResource`

--- a/libraries/consul_definition.rb
+++ b/libraries/consul_definition.rb
@@ -41,7 +41,7 @@ module ConsulCookbook
 
       def params_to_json
         final_parameters = parameters
-        final_parameters = final_parameters.merge(name: name) if final_parameters[:name].nil?
+        final_parameters = final_parameters.merge(name: name) if %w(check service).include?(type) && final_parameters[:name].nil?
         JSON.pretty_generate(type => final_parameters)
       end
 


### PR DESCRIPTION
# Description

This enables Multiple Service Definitions
(https://www.consul.io/docs/agent/services.html#multiple-service-definitions)
(and Multiple Checks Definitions) on a `consul_definition`.

## Issues Resolved

https://github.com/sous-chefs/consul/issues/568

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
