### PR TITLE
support linux arm64 for binary downloads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Support binary download for linux arm64
+
 ## [4.0.5](https://github.com/sous-chefs/consul/tree/v4.0.5) (2020-08-31)
 
 - Change segments to Array type #549

--- a/libraries/consul_installation_binary.rb
+++ b/libraries/consul_installation_binary.rb
@@ -90,6 +90,7 @@ module ConsulCookbook
         when 'x86_64', 'amd64' then ['consul', resource.version, node['os'], 'amd64'].join('_')
         when /i\d86/ then ['consul', resource.version, node['os'], '386'].join('_')
         when /^arm/ then ['consul', resource.version, node['os'], 'arm'].join('_')
+        when 'aarch64' then ['consul', resource.version, node['os'], 'arm64'].join('_')
         else ['consul', resource.version, node['os'], node['kernel']['machine']].join('_')
         end.concat('.zip')
       end


### PR DESCRIPTION
an aws graviton instance (t4g, m6g, etc) shows the arch as `aarch64`. downloads typically represent
the 64-bit arm architecture as `arm64` rather than `aarch64`. this pull adds that translation.

fixes #574
