### PR TITLE
Changed type of log_rotate_bytes to Integer.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Change Log
 
+## Unreleased
+
+- Changed type of log_rotate_bytes to Integer.
+
 ## [4.0.6](https://github.com/sous-chefs/consul/tree/v4.0.6) (2020-10-01)
 
 - Support binary download for linux arm64

--- a/libraries/consul_config_v1.rb
+++ b/libraries/consul_config_v1.rb
@@ -99,7 +99,7 @@ module ConsulCookbook
       attribute(:log_file, kind_of: String)
       attribute(:log_level, equal_to: %w(INFO DEBUG WARN ERR))
       attribute(:log_rotate_duration, kind_of: String)
-      attribute(:log_rotate_bytes, kind_of: String)
+      attribute(:log_rotate_bytes, kind_of: Integer)
       attribute(:log_rotate_max_files, kind_of: Integer)
       attribute(:node_id, kind_of: String)
       attribute(:node_name, kind_of: String)


### PR DESCRIPTION
# Description

This changes the config option of `log_rotate_bytes` to Integer. Using the current option of a string provides the following output:

```
Nov 12 13:48:29 VM-719e433f-7079-44bc-bff2-db102fae7eee consul[9081]: ==> Error parsing /etc/consul/consul.json: 1 error(s) decoding:
Nov 12 13:48:29 VM-719e433f-7079-44bc-bff2-db102fae7eee consul[9081]: * 'log_rotate_bytes' expected type 'int', got unconvertible type 'string'
Nov 12 13:48:29 VM-719e433f-7079-44bc-bff2-db102fae7eee systemd[1]: consul.service: main process exited, code=exited, status=1/FAILURE
Nov 12 13:48:29 VM-719e433f-7079-44bc-bff2-db102fae7eee systemd[1]: Unit consul.service entered failed state.
Nov 12 13:48:29 VM-719e433f-7079-44bc-bff2-db102fae7eee systemd[1]: consul.service failed.
```

## Check List

- [ ] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
