### PR TITLE
When diplomat is not installed, failed with correct message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Proper error messages when installing diplomat for issues such as #583
+
 ## 4.3.1 - *2020-12-21*
 
 - Added the renamed parameters from consul 1.0.0:

--- a/libraries/consul_acl.rb
+++ b/libraries/consul_acl.rb
@@ -77,9 +77,9 @@ module ConsulCookbook
       def configure_diplomat
         begin
           require 'diplomat'
-        rescue LoadError
+        rescue LoadError => e
           raise 'The diplomat gem is required; ' \
-                'include recipe[consul::client_gem] to install.'
+                "include recipe[consul::client_gem] to install, details: #{e}"
         end
         Diplomat.configure do |config|
           config.url = new_resource.url

--- a/libraries/consul_policy.rb
+++ b/libraries/consul_policy.rb
@@ -87,9 +87,9 @@ module ConsulCookbook
       def configure_diplomat
         begin
           require 'diplomat'
-        rescue LoadError
+        rescue LoadError => e
           raise 'The diplomat gem is required; ' \
-                'include recipe[consul::client_gem] to install.'
+                "include recipe[consul::client_gem] to install, details: #{e}"
         end
         Diplomat.configure do |config|
           config.url = new_resource.url

--- a/libraries/consul_role.rb
+++ b/libraries/consul_role.rb
@@ -87,9 +87,9 @@ module ConsulCookbook
       def configure_diplomat
         begin
           require 'diplomat'
-        rescue LoadError
+        rescue LoadError => e
           raise 'The diplomat gem is required; ' \
-                'include recipe[consul::client_gem] to install.'
+                "include recipe[consul::client_gem] to install, details: #{e}"
         end
         Diplomat.configure do |config|
           config.url = new_resource.url

--- a/libraries/consul_token.rb
+++ b/libraries/consul_token.rb
@@ -104,9 +104,9 @@ module ConsulCookbook
       def configure_diplomat
         begin
           require 'diplomat'
-        rescue LoadError
+        rescue LoadError => e
           raise 'The diplomat gem is required; ' \
-                'include recipe[consul::client_gem] to install.'
+                "include recipe[consul::client_gem] to install, details: #{e}"
         end
         Diplomat.configure do |config|
           config.url = new_resource.url


### PR DESCRIPTION
This will ease investigations such as https://github.com/sous-chefs/consul/issues/582

# Description

Will have a clear error message if diplomat fails to install such as a transitive dependency error.

Such message will be:

```
The diplomat gem is required; include recipe[consul::client_gem] to install, details: Unable to activate diplomat-2.5.0, because faraday-1.0.1 conflicts with faraday (~> 1.3)
```

instead of misleading:
```
The diplomat gem is required; include recipe[consul::client_gem] to install.
```

## Issues Resolved

https://github.com/sous-chefs/consul/issues/582
