### PR TITLE
Added the ability to set nofile limits on service init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## Unreleased
 
+## 4.3.3 - *2021-03-16*
+
+- Added the ability to define open file limit for the consul service
+
 ## 4.3.2 - *2021-02-11*
 
 - Proper error messages when installing diplomat for issues such as #583

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 4.3.3 - *2021-03-16*
-
 - Added the ability to define open file limit for the consul service
 
 ## 4.3.2 - *2021-02-11*

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -10,6 +10,8 @@ extend ConsulCookbook::Helpers
 default['consul']['service_name'] = 'consul'
 default['consul']['service_user'] = 'consul'
 default['consul']['service_group'] = 'consul'
+# To set the open file limit for the service. If unset system default is used
+default['consul']['service_nofile'] = nil
 default['consul']['create_service_user'] = true
 
 default['consul']['config']['path'] = join_path config_prefix_path, 'consul.json'

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -3,7 +3,7 @@ driver:
   name: vagrant
 
 provisioner:
-  name: chef_solo
+  name: chef_zero
   product_name: chef
   enforce_idempotency: true
   multiple_converge: 2
@@ -50,6 +50,7 @@ suites:
           acl_master_token: doublesecret
           acl_datacenter: FortMeade
           acl_default_policy: deny
+        service_nofile: 9001
     excludes:
       - windows-2012r2
       - windows-2016

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Application cookbook which installs and configures Consul.'
 source_url        'https://github.com/sous-chefs/consul'
 issues_url        'https://github.com/sous-chefs/consul/issues'
 chef_version      '>= 13.4'
-version           '4.3.3'
+version           '4.3.2'
 
 supports 'centos', '>= 7.0'
 supports 'redhat', '>= 7.0'

--- a/metadata.rb
+++ b/metadata.rb
@@ -6,7 +6,7 @@ description       'Application cookbook which installs and configures Consul.'
 source_url        'https://github.com/sous-chefs/consul'
 issues_url        'https://github.com/sous-chefs/consul/issues'
 chef_version      '>= 13.4'
-version           '4.3.2'
+version           '4.3.3'
 
 supports 'centos', '>= 7.0'
 supports 'redhat', '>= 7.0'

--- a/templates/default/systemd.service.erb
+++ b/templates/default/systemd.service.erb
@@ -10,6 +10,7 @@ ExecReload=/bin/kill -<%= @reload_signal %> $MAINPID
 KillSignal=<%= @stop_signal %>
 User=<%= @user %>
 WorkingDirectory=<%= @directory %>
+<%= "LimitNOFILE=#{node['consul']['service_nofile']}" if node['consul']['service_nofile'] %>
 
 [Install]
 WantedBy=multi-user.target

--- a/templates/default/sysvinit.service.erb
+++ b/templates/default/sysvinit.service.erb
@@ -14,6 +14,8 @@
 # Short-Description: Manage the consul agent
 ### END INIT INFO
 
+<%= "limit nofile #{node['consul']['service_nofile']}" if node['consul']['service_nofile'] %>
+
 prog="<%= File.basename(@daemon) %>"
 user="<%= @user %>"
 exec="<%= @daemon %>"

--- a/templates/default/upstart.service.erb
+++ b/templates/default/upstart.service.erb
@@ -5,6 +5,8 @@ description "<%= @name %>"
 start on runlevel [2345]
 stop on runlevel [!2345]
 
+<%= "limit nofile #{node['consul']['service_nofile']}" if node['consul']['service_nofile'] %>
+
 respawn
 respawn limit 10 5
 umask 022

--- a/test/integration/default/default_spec.rb
+++ b/test/integration/default/default_spec.rb
@@ -71,6 +71,10 @@ describe directory(data_dir) do
   its('mode') { should cmp '0750' }
 end
 
+describe command('grep files /proc/$(pgrep consul)/limits') do
+  its(:stdout) { should include '9001' }
+end
+
 # describe file("#{confd_dir}/consul_definition_check.json") do
 #   it { should be_file }
 #   it { should be_owned_by 'root' }


### PR DESCRIPTION
# Description

In busy environments consul may require more file descriptors than the system allows by default. This change allows you to define a new set of limits based on attributes.

## Issues Resolved

https://www.consul.io/docs/troubleshoot/common-errors#too-many-open-files

## Check List

- [x] All tests pass. See TESTING.md for details.
- [x] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
