### PR TITLE
Add additional advertise_addr_ipv* attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `advertise_addr_ipv4` and `advertise_addr_ipv6` attributes
+
 ## 4.4.0 - *2021-03-16*
 
 - Added the ability to define open file limit for the consul service

--- a/libraries/consul_config_v1.rb
+++ b/libraries/consul_config_v1.rb
@@ -50,6 +50,8 @@ module ConsulCookbook
       attribute(:acl_ttl, kind_of: String)
       attribute(:addresses, kind_of: [Hash, Mash])
       attribute(:advertise_addr, kind_of: String)
+      attribute(:advertise_addr_ipv4, kind_of: String)
+      attribute(:advertise_addr_ipv6, kind_of: String)
       attribute(:advertise_addr_wan, kind_of: String)
       attribute(:atlas_acl_token, kind_of: String)
       attribute(:atlas_infrastructure, kind_of: String)
@@ -177,6 +179,8 @@ module ConsulCookbook
           acl_ttl
           addresses
           advertise_addr
+          advertise_addr_ipv4
+          advertise_addr_ipv6
           advertise_addr_wan
           autopilot
           auto_encrypt


### PR DESCRIPTION
Signed-off-by: Edgaras Giedrė <edgaras.giedre@hostinger.com>

# Description

Adds additional attributes:
`advertise_addr_ipv4`
`advertise_addr_ipv6`

https://www.consul.io/docs/agent/options#advertise_addr_ipv4
https://www.consul.io/docs/agent/options#advertise_addr_ipv6

## Issues Resolved

## Check List

- [x] All tests pass. See TESTING.md for details.
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
