### PR TITLE
Automated PR: Cookstyle Changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @sous-chefs/consul
+* @sous-chefs/maintainers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Exclude Chef Infra Client >= 17.0 until Poise support has been removed
 - resolved cookstyle error: Policyfile.rb:2:1 warning: `Chef/Deprecations/PolicyfileCommunitySource`
 - Standardise files with files in sous-chefs/repo-management
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- resolved cookstyle error: Policyfile.rb:2:1 warning: `Chef/Deprecations/PolicyfileCommunitySource`
 ## 4.5.1 - *2021-06-01*
 
 ## 4.5.0 - *2021-03-31*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,11 @@
 ## Unreleased
 
 - resolved cookstyle error: Policyfile.rb:2:1 warning: `Chef/Deprecations/PolicyfileCommunitySource`
+- Standardise files with files in sous-chefs/repo-management
+
 ## 4.5.1 - *2021-06-01*
+
+- Standardise files with files in sous-chefs/repo-management
 
 ## 4.5.0 - *2021-03-31*
 

--- a/Policyfile.rb
+++ b/Policyfile.rb
@@ -1,4 +1,4 @@
 name 'consul'
-default_source :community
+default_source :supermarket
 cookbook 'consul', path: '.'
 run_list 'consul::default'

--- a/kitchen.dokken.yml
+++ b/kitchen.dokken.yml
@@ -2,7 +2,7 @@
 driver:
   name: dokken
   privileged: true
-  chef_version: <%= ENV['CHEF_VERSION'] || 'current' %>
+  chef_version: <%= ENV['CHEF_VERSION'] || '16' %> # >= 17.0 does not support Poise
   env: [CHEF_LICENSE=accept]
 
 transport:

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,7 +5,7 @@ license           'Apache-2.0'
 description       'Application cookbook which installs and configures Consul.'
 source_url        'https://github.com/sous-chefs/consul'
 issues_url        'https://github.com/sous-chefs/consul/issues'
-chef_version      '>= 13.4'
+chef_version      '>= 13.4', '< 17.0' # >= 17.0 does not support Poise
 version           '4.5.1'
 
 supports 'centos', '>= 7.0'


### PR DESCRIPTION
Hey!
I ran Cookstyle 7.16.1 against this repo and here are the results.
This repo was selected due to the topics of chef-cookbook

## Changes

### Issues found and resolved with Policyfile.rb

 - 2:1 warning: `Chef/Deprecations/PolicyfileCommunitySource` - The Policyfile source of `:community` has been replaced with `:supermarket`. (https://docs.chef.io/workstation/cookstyle/chef_deprecations_policyfilecommunitysource)