### PR TITLE
adds support for the enable_additional_node_meta_txt directive.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Change Log
 
+## Unreleased
+
 ## 4.5.2 - *2021-08-12*
 
 - Added `enable_additional_node_meta_txt` attributes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,6 @@
 
 ## Unreleased
 
-## 4.5.2 - *2021-08-12*
-
 - Added `enable_additional_node_meta_txt` attributes
 
 ## 4.6.0 - *2021-08-29*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Change Log
 
-## Unreleased
+## 4.5.2 - *2021-08-12*
+
+- Added `enable_additional_node_meta_txt` attributes
 
 ## 4.6.0 - *2021-08-29*
 

--- a/libraries/consul_config_v1.rb
+++ b/libraries/consul_config_v1.rb
@@ -82,6 +82,7 @@ module ConsulCookbook
       attribute(:dns_config, kind_of: [Hash, Mash])
       attribute(:domain, kind_of: String)
       attribute(:enable_acl_replication, equal_to: [true, false])
+      attribute(:enable_additional_node_meta_txt, equal_to: [true, false])
       attribute(:enable_agent_tls_for_checks, equal_to: [true, false])
       attribute(:enable_central_service_config, equal_to: [true, false])
       attribute(:enable_debug, equal_to: [true, false])
@@ -200,6 +201,7 @@ module ConsulCookbook
           dns_config
           domain
           enable_acl_replication
+          enable_additional_node_meta_txt
           enable_central_service_config
           enable_debug
           enable_local_script_checks


### PR DESCRIPTION
# Description

Adds support for the [enable_additional_node_meta_txt](https://www.consul.io/docs/agent/options#enable_additional_node_meta_txt) directive. 
