### PR TITLE
Add additional advertise_addr_wan_ipv* attributes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added `advertise_addr_wan_ipv4` and `advertise_addr_wan_ipv6` attributes
+
 ## 4.7.0 - *2021-08-29*
 
 - Added `enable_additional_node_meta_txt` attributes

--- a/libraries/consul_config_v1.rb
+++ b/libraries/consul_config_v1.rb
@@ -53,6 +53,8 @@ module ConsulCookbook
       attribute(:advertise_addr_ipv4, kind_of: String)
       attribute(:advertise_addr_ipv6, kind_of: String)
       attribute(:advertise_addr_wan, kind_of: String)
+      attribute(:advertise_addr_wan_ipv4, kind_of: String)
+      attribute(:advertise_addr_wan_ipv6, kind_of: String)
       attribute(:atlas_acl_token, kind_of: String)
       attribute(:atlas_infrastructure, kind_of: String)
       attribute(:atlas_join, equal_to: [true, false])
@@ -183,6 +185,8 @@ module ConsulCookbook
           advertise_addr_ipv4
           advertise_addr_ipv6
           advertise_addr_wan
+          advertise_addr_wan_ipv4
+          advertise_addr_wan_ipv6
           autopilot
           auto_encrypt
           bind_addr


### PR DESCRIPTION
Signed-off-by: Edgaras Giedrė <edgaras.giedre@hostinger.com>

# Description

Adds additional attributes:
`advertise_addr_wan_ipv4`
`advertise_addr_wan_ipv6`

https://www.consul.io/docs/agent/options#advertise_addr_wan_ipv4
https://www.consul.io/docs/agent/options#advertise_addr_wan_ipv6

## Issues Resolved
## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
