### PR TITLE
allow overriding program in consul_service

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix setting `program` in `consul_service` resource
+
 ## 5.0.0 - *2021-11-22*
 
 - Remove Poise dependencies

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,11 +44,11 @@ module ConsulCookbook
       windows? ? join_path(program_files, 'consul', 'data') : join_path('/var/lib', 'consul')
     end
 
-    def command(config_file, config_dir)
+    def command(program, config_file, config_dir)
       if windows?
         %(agent -config-file="#{config_file}" -config-dir="#{config_dir}")
       else
-        "/usr/local/bin/consul agent -config-file=#{config_file} -config-dir=#{config_dir}"
+        "#{program} agent -config-file=#{config_file} -config-dir=#{config_dir}"
       end
     end
   end

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -45,7 +45,7 @@ action :enable do
       },
       Service: {
         Environment: new_resource.environment.map { |key, val| %("#{key}=#{val}") }.join(' '),
-        ExecStart: command(new_resource.config_file, new_resource.config_dir),
+        ExecStart: command(new_resource.program, new_resource.config_file, new_resource.config_dir),
         ExecReload: '/bin/kill -HUP $MAINPID',
         KillSignal: 'TERM',
         User: new_resource.user,


### PR DESCRIPTION
# Description

Use `program` set in `consul_service` resource when building the Systemd unit file.

## Issues Resolved

Fixes #600 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
