### PR TITLE
Add license_path consul_config property for enterprise installations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added setting `license_path` in `consul_config` resource for enterprise installations
+
 ## 5.1.0 - *2021-12-01*
 
 - Support `:stop` action for `consul_service` resource

--- a/resources/config_v1.rb
+++ b/resources/config_v1.rb
@@ -75,6 +75,7 @@ property :http_api_response_headers, [Hash, Mash]
 property :http_config, [Hash, Mash]
 property :key_file, String
 property :leave_on_terminate, [true, false]
+property :license_path, String
 property :limits, [Hash, Mash]
 property :log_file, String
 property :log_level, String, equal_to: %w(INFO DEBUG WARN ERR)
@@ -193,6 +194,7 @@ def params_to_json
     gossip_wan
     http_config
     leave_on_terminate
+    license_path
     limits
     log_file
     log_level


### PR DESCRIPTION
# Description

Adds license_path configuration option as defined by Hasicorp's Consul licensing documentation as of 1.10.0.  https://www.consul.io/docs/enterprise/license/overview

Similar to https://github.com/sous-chefs/consul/pull/571, I have overrode the resource in my local environment where we have an enterprise license to validate.

```
Nov 29 23:11:55 ip-172-30-8-179 consul[4602]: 2021-11-29T23:11:55.086Z [INFO]  agent: initialized license: id=xxxxxxxxx expiration="1970-01-01 00:00:00 +0000 UTC>
Nov 29 23:11:55 ip-172-30-8-179 consul[4602]: 2021-11-29T23:11:55.087Z [INFO]  agent: started routine: routine=license-manager
Nov 29 23:11:55 ip-172-30-8-179 consul[4602]: 2021-11-29T23:11:55.087Z [INFO]  agent: started routine: routine=license-monitor
```

## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
