### PR TITLE
add consul_service stop action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Support `:stop` action for `consul_service` resource
+
 ## 5.0.1 - *2021-11-24*
 
 - Fix setting `program` in `consul_service` resource

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -91,3 +91,9 @@ action :disable do
     action %i(disable delete)
   end
 end
+
+action :stop do
+  service 'consul' do
+    action :stop
+  end
+end


### PR DESCRIPTION
# Description

PR switching to new custom resources dropped support for the `:stop` action in `consul_service`.

cc @ramereth @josqu4red 🙏 

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [x] New functionality has been documented in the README if applicable.