### PR TITLE
Fix wrong number of arguments when calling action  service on Windows platform

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix wrong number of arguments when calling action `:enable` service on Windows platform
+
 ## 5.2.0 - *2021-12-01*
 
 - Added setting `license_path` in `consul_config` resource for enterprise installations

--- a/libraries/helpers.rb
+++ b/libraries/helpers.rb
@@ -44,7 +44,7 @@ module ConsulCookbook
       windows? ? join_path(program_files, 'consul', 'data') : join_path('/var/lib', 'consul')
     end
 
-    def command(program, config_file, config_dir)
+    def command(config_file, config_dir, program = '/usr/local/bin/consul')
       if windows?
         %(agent -config-file="#{config_file}" -config-dir="#{config_dir}")
       else

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -45,7 +45,7 @@ action :enable do
       },
       Service: {
         Environment: new_resource.environment.map { |key, val| %("#{key}=#{val}") }.join(' '),
-        ExecStart: command(new_resource.program, new_resource.config_file, new_resource.config_dir),
+        ExecStart: command(new_resource.config_file, new_resource.config_dir, new_resource.program),
         ExecReload: '/bin/kill -HUP $MAINPID',
         KillSignal: 'TERM',
         User: new_resource.user,


### PR DESCRIPTION
# Description

Fixes enabling consul service on Windows platform.  In [4.8.0](https://github.com/sous-chefs/consul/blob/4.8.0/libraries/helpers.rb#L47-L53) only 2 arguments were required, and in [5.0.0](https://github.com/sous-chefs/consul/blob/main/libraries/helpers.rb#L47-L53), this was updated to allow for a binary path to be passed, but the [Windows service](https://github.com/sous-chefs/consul/blob/main/resources/service_windows.rb#L38) doesn't use this and only passes 2 arguments.

I opted for moving the optional argument to the end of the method args instead of passing a bogus value through the Windows service command call, but will change it if desired.

```
     ================================================================================
     Error executing action `enable` on resource 'consul_service[consul]'
     ================================================================================
     
     ArgumentError
     -------------
     wrong number of arguments (given 2, expected 3)
     
     Cookbook Trace: (most recent call first)
     ----------------------------------------
     C:/Users/ADMINI~1/AppData/Local/Temp/kitchen/cache/cookbooks/consul/libraries/helpers.rb:47:in `command'
     C:/Users/ADMINI~1/AppData/Local/Temp/kitchen/cache/cookbooks/consul/resources/service_windows.rb:38:in `block (2 levels) in class_from_file'
     C:/Users/ADMINI~1/AppData/Local/Temp/kitchen/cache/cookbooks/consul/resources/service_windows.rb:36:in `block in class_from_file'
     
     Resource Declaration:
```

## Issues Resolved

N/A

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
