### PR TITLE
fix up_to_date? methods for acl tokens and policies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix idempotency checks for `consul_token` and `consul_policy`
+
 ## 5.3.0 - *2022-01-04*
 
 - Fix wrong number of arguments when calling action `:enable` service on Windows platform

--- a/resources/policy.rb
+++ b/resources/policy.rb
@@ -50,9 +50,10 @@ action_class do
       return false if old_policy_id.empty?
       old_policy = Diplomat::Policy.read(old_policy_id.first['ID'], {}, :return)
       return false if old_policy.nil?
-      old_policy.first.select! { |k, _v| %w(Name Description Rules).include?(k) }
+      old_policy.select! { |k, _v| %w(Name Description Datacenters Rules).include?(k) }
       old_policy['Description'].downcase!
-      old_policy.first == new_resource.to_acl
+      old_policy['Datacenters'] = [] unless old_policy.key?('Datacenters')
+      old_policy == new_resource.to_acl
     end
   end
 end

--- a/resources/token.rb
+++ b/resources/token.rb
@@ -59,7 +59,7 @@ action_class do
       old_token = Diplomat::Token.read(old_token_id.first['AccessorID'], {}, :return)
       old_token.select! { |k, _v| %w(SecretID Description Policies Local).include?(k) }
       old_token['Description'].downcase!
-      old_token['Policies'].map! { |p| p.slice('Name') }
+      old_token['Policies'].map! { |p| p.slice('Name') } unless old_token['Policies'].nil?
       old_token == new_resource.to_acl
     end
   end

--- a/resources/token.rb
+++ b/resources/token.rb
@@ -59,6 +59,7 @@ action_class do
       old_token = Diplomat::Token.read(old_token_id.first['AccessorID'], {}, :return)
       old_token.select! { |k, _v| %w(SecretID Description Policies Local).include?(k) }
       old_token['Description'].downcase!
+      old_token['Policies'].map! { |p| p.slice('Name') }
       old_token == new_resource.to_acl
     end
   end


### PR DESCRIPTION
# Description

The consul_token and consul_policy resources are not idempotent since the logic for comparing new/old values isn't valid (maybe it was for an older version of Consul/Diplomat at the time it was written). I tested on Consul 1.10.4 (Diplomat gem 2.5.1).

## Check List

- [x] A summary of changes made is included in the CHANGELOG under `## Unreleased`
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable.
